### PR TITLE
kicad5.0で作成したschファイルのsheetname及びsheetfileの読み込みに対応

### DIFF
--- a/src/kidivis/review.py
+++ b/src/kidivis/review.py
@@ -231,9 +231,9 @@ def get_sch_subsheets(sch_path):
 
             name = m.group('name')
             value = m.group('value')
-            if name == "Sheetname" or name == "Sheet name":
+            if name == 'Sheetname' or name == 'Sheet name':
                 sheetname = value
-            elif name == "Sheetfile" or name == "Sheet file":
+            elif name == 'Sheetfile' or name == 'Sheet file':
                 sheetfile = value
 
         pos = sheet_end_pos + 1


### PR DESCRIPTION
kicad5.0と現行の9.0では`.kicad_sch`ファイルの仕様がどうやら異なるらしく，古いファイルの読み込みに失敗したため修正を試みた

# 5.0と9.0の差分
sheetの名前とファイル指定の際に，profileの表記が異なる

現行の9.0では
<img width="750" height="281" alt="image" src="https://github.com/user-attachments/assets/2bd0e323-880a-4dac-af66-9947470cdabd" />
のように`(property "Sheetname" "sequence_start"`とスペースが入らない表記だが，
5.0では
<img width="750" height="281" alt="image" src="https://github.com/user-attachments/assets/4287e839-bb43-40fb-b28b-c845f214102f" />
のように”(property "Sheet name" "sequence_start" (id 0) (at 83.82 114.8584 0)”とスペースが入る表記だった

# Sheetname，Sheetfileの取得
Sheetname，Sheetfile取得時，propertyの種類を判定する際の条件に`Sheet name`と`Sheet file`を追加
正常に5.0で作成したファイルが開けるようになった